### PR TITLE
Fix some issues found in v2 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ Here are the steps to get those credentials:
 
 ### `offerName`
 
-**Required** The name of the offer.
+**Required** The name of the offer if `offerType` is `application_offer`. The id of the offer if `offerType` is `vm_image_offer`.
 
 ### `planName`
 
-**Required** The name of the plan.
+**Required** The name of the plan if `offerType` is `application_offer`. The id of the plan if `offerType` is `vm_image_offer`.
 
 ### `offerType`
 
@@ -100,8 +100,8 @@ with:
 ```terminal
 uses: microsoft/microsoft-partner-center-github-action@v1
 with:
-  offerName: offerName
-  planName: planName
+  offerName: offerId
+  planName: planId
   clientId: clientId
   secretValue: secretValue
   tenantId: tenantId

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,7 +46,7 @@ application_get_product_id() {
     echo $products | jq . >&2
 
     nextProductsLink=$(echo ${products} | jq -r '.nextLink')
-    productId=$(echo ${products} | jq -r --arg offerName $offerName '.value | .[] | select(.name==$offerName) | .id')
+    productId=$(echo ${products} | jq -r --arg offerName "$offerName" '.value | .[] | select(.name==$offerName) | .id')
 
     echo "offer finding result in first page: " $nextProductsLink $productId >&2
 
@@ -67,7 +67,7 @@ application_get_product_id() {
         echo $products | jq . >&2
         
         nextProductsLink=$(echo ${products} | jq -r '.nextLink')
-        productId=$(echo ${products} | jq -r --arg offerName $offerName '.value | .[] | select(.name==$offerName) | .id')
+        productId=$(echo ${products} | jq -r --arg offerName "$offerName" '.value | .[] | select(.name==$offerName) | .id')
 
         echo "offer finding result in next page: " $nextProductsLink $productId >&2
 
@@ -98,7 +98,7 @@ application_get_variant_id() {
     echo "all plans under the offer: " >&2
     echo $variants | jq . >&2
 
-    variantId=$(echo ${variants} | jq -r --arg planName $planName '.value | .[] | select(.friendlyName==$planName) | .id')
+    variantId=$(echo ${variants} | jq -r --arg planName "$planName" '.value | .[] | select(.friendlyName==$planName) | .id')
 
     validate_status "Get plan id by name"
 


### PR DESCRIPTION
The PR is to fix two issues found in v2 release:
* [enclose offerName and planName in double quote](https://github.com/microsoft/microsoft-partner-center-github-action/commit/b4ea11cf8a28cb9bdda04917767a7b6591e95c78), so that offerName / planName with whitespaces are supported.
* [offerName/planName should be provided with offerId/planId for vm offer](https://github.com/microsoft/microsoft-partner-center-github-action/commit/4c299fde48bb37f065dea42e0757143f3dd6043a)

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>