### PR TITLE
VM offer failed to be updated

### DIFF
--- a/.github/workflows/update-application-offer.yml
+++ b/.github/workflows/update-application-offer.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Update offer artifact
         id: update-offer-artifact
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/.github/workflows/update-vm-offer.yml
+++ b/.github/workflows/update-vm-offer.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Update offer artifact
         id: update-offer-artifact
-        uses: microsoft/microsoft-partner-center-github-action@v3.1
+        uses: microsoft/microsoft-partner-center-github-action@v3.2
         with:
           offerId: ${{ env.offerId }}
           planId: ${{ env.planId }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Here are the steps to get those credentials:
 ### For Application Offer
 
 ```terminal
-uses: microsoft/microsoft-partner-center-github-action@v3.1
+uses: microsoft/microsoft-partner-center-github-action@v3.2
 with:
   offerId: offerId
   planId: planId
@@ -104,7 +104,7 @@ with:
 ### For Virtual Machine Offer
 
 ```terminal
-uses: microsoft/microsoft-partner-center-github-action@v3.1
+uses: microsoft/microsoft-partner-center-github-action@v3.2
 with:
   offerId: offerId
   planId: planId

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -400,7 +400,7 @@ vm_get_all_current_all_image_versions() {
     fi
 }
 
-vm_applend_new_draft_tech_configuration() {
+vm_append_new_draft_tech_configuration() {
     echo "Start updating technical configurations."
     # Mark existing draft as delete
 
@@ -519,7 +519,7 @@ elif [ $offerType == "vm_image_offer" ]; then
 
     vm_get_all_current_all_image_versions
 
-    vm_applend_new_draft_tech_configuration
+    vm_append_new_draft_tech_configuration
 
     vm_check_configuration_status
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -415,8 +415,8 @@ vm_applend_new_draft_tech_configuration() {
         echo "debug: imageVersionsAppended: $imageVersionsAppended" >&2
     fi
 
-    # Put things together to form the reqeust data
-    requestData={\"\$schema\":\"https://product-ingestion.azureedge.net/schema/configure/2022-03-01-preview2\",\"resources\":[{\"\$schema\":\"https://product-ingestion.azureedge.net/schema/virtual-machine-plan-technical-configuration/2022-03-01-preview3\",\"product\":{\"externalId\":\"${offerId}\"},\"plan\":{\"externalId\":\"${planId}\"},\"operatingSystem\":{\"family\":\"${operatingSystemFamily}\",\"type\":\"${operatingSystemType}\"},\"skus\":[{\"imageType\":\"${imageType}\",\"skuId\":\"${planId}\"}],\"vmImageVersions\":${imageVersionsAppended}}]}
+    # Put things together to form the request data
+    requestData={\"\$schema\":\"https://schema.mp.microsoft.com/schema/configure/2022-03-01-preview2\",\"resources\":[{\"\$schema\":\"https://schema.mp.microsoft.com/schema/virtual-machine-plan-technical-configuration/2022-03-01-preview3\",\"product\":{\"externalId\":\"${offerId}\"},\"plan\":{\"externalId\":\"${planId}\"},\"operatingSystem\":{\"family\":\"${operatingSystemFamily}\",\"type\":\"${operatingSystemType}\"},\"skus\":[{\"imageType\":\"${imageType}\",\"skuId\":\"${planId}\"}],\"vmImageVersions\":${imageVersionsAppended}}]}
 
     if [ $verbose == 0 ]; then
         echo "debug: requestData: $requestData" >&2


### PR DESCRIPTION
This pull request includes a fix to the schema URL which caused the failure to update vm offer. See more information from [Product Ingestion API for virtual machines](https://learn.microsoft.com/partner-center/marketplace-offers/product-ingestion-api-vm).

It also improves consistency and fix typos.

### Major fix:
* Fixed the schema URL in the `requestData` variable in `entrypoint.sh`.

### Typo fix:
* Corrected the function name from `vm_applend_new_draft_tech_configuration` to `vm_append_new_draft_tech_configuration` in `entrypoint.sh` [[1]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L403-R403) [[2]](diffhunk://#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2L522-R522).

### Reference to the upcoming new release `v3.2`
* Updated `microsoft-partner-center-github-action` from version `v3.1` to `v3.2` in `.github/workflows/update-application-offer.yml`.
* Updated `microsoft-partner-center-github-action` from version `v3.1` to `v3.2` in `.github/workflows/update-vm-offer.yml`.
* Updated `microsoft-partner-center-github-action` from version `v3.1` to `v3.2` in `README.md` for both Application Offer and Virtual Machine Offer sections [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L92-R92) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L107-R107).

Signed-off-by: Jianguo Ma <jiangma@microsoft.com>